### PR TITLE
exclude spring-boot-starter-logging for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,9 @@ dependencies {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
     }
     implementation 'org.springframework.boot:spring-boot-starter-log4j2:2.6.1'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation ('org.springframework.boot:spring-boot-starter-test') {
+		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+	}
 }
 
 test {


### PR DESCRIPTION
Fix tests : 
```
Caused by: org.apache.logging.log4j.LoggingException: log4j-slf4j-impl cannot be present with log4j-to-slf4j
``` 